### PR TITLE
Add support for csrf token in fuzzbuster module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "termios 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -199,7 +199,7 @@ dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -360,7 +360,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "number_prefix 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -816,6 +816,7 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_env_logger 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "terminal_size 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1341,7 +1342,7 @@ dependencies = [
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)" = "12229c14a0f65c4f1cb046a3b52047cdd9da1f4b30f8a39c5063c8bae515e252"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
-"checksum regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8f0a0bcab2fd7d1d7c54fa9eae6f43eddeb9ce2e7352f8518a814a4f65d60c58"
+"checksum regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0b2f0808e7d7e4fb1cb07feb6ff2f4bc827938f24f8c2e6a3beb7370af544bdd"
 "checksum regex-syntax 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "dcfd8681eebe297b81d98498869d4aae052137651ad7b96822f09ceb690d0a96"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ indicatif = "^0.11.0"
 chrono = "^0.4.6"
 terminal_size = "^0.1.8"
 itertools = "^0.8.0"
+regex = "^1.1.7"
 
 [dependencies.clap]
 version = "^2.33"

--- a/examples/login-server-csrf.js
+++ b/examples/login-server-csrf.js
@@ -1,0 +1,46 @@
+var express = require("express");
+var bodyParser = require("body-parser");
+var app = express();
+
+var DEFAULT = "Hello World!";
+var vhosts = ["1.test.local", "10.test.local", "15.test.local"];
+
+app.use(bodyParser.json());
+
+var users = {
+    admin: "password",
+    root: "toor",
+    administrator: "password123"
+}
+
+CSRFs = new Set();
+
+app.get("/csrf", function (req, res) {
+    let token = (Math.random() + 1).toString(36).substring(8);
+    CSRFs.add(token);
+    res.status(200).send(JSON.stringify({csrf: token}));
+})
+
+app.post("/login", function (req, res) {
+    if (!CSRFs.delete(req.body.csrf)) {
+        res.status(401).send("Missing CSRF token");
+    }
+    else if (users[req.body.user] && users[req.body.user] === req.body.password) {
+        res.send("Logged in");
+    } else {
+        res.status(401).send("Invalid user/password");
+    }
+})
+
+app.all("/*", function (req, res) {
+    if (vhosts.some(x => x === req.hostname)) {
+        return res.send(req.hostname);
+    }
+
+    res.send("Hello World!");
+});
+
+app.listen(3000, function () {
+    console.log("Example app listening on port 3000!");
+});
+

--- a/examples/wordlist
+++ b/examples/wordlist
@@ -1,4 +1,6 @@
 # invalid
+admin
+password
 0
 1
 2

--- a/src/fuzzbuster/result_processor.rs
+++ b/src/fuzzbuster/result_processor.rs
@@ -37,23 +37,6 @@ impl FuzzScanProcessor {
     pub fn maybe_add_result(&mut self, res: SingleFuzzScanResult) -> bool {
         trace!("{:?}", res);
 
-        if self.config.ignore.len() != 0 {
-            for code in &self.config.ignore {
-                if res.status.starts_with(code) {
-                    return false;
-                }
-            }
-        }
-
-        if self.config.include.len() != 0 {
-            for code in &self.config.include {
-                if res.status.starts_with(code) {
-                    self.results.push(res);
-                    return true;
-                }
-            }
-        }
-
         if self.config.ignore_body.len() != 0 {
             for ignore in &self.config.ignore_body {
                 if res.body.contains(ignore) {
@@ -65,6 +48,23 @@ impl FuzzScanProcessor {
         if self.config.include_body.len() != 0 {
             for include in &self.config.include_body {
                 if res.body.contains(include) {
+                    self.results.push(res);
+                    return true;
+                }
+            }
+        }
+
+        if self.config.ignore.len() != 0 {
+            for code in &self.config.ignore {
+                if res.status.starts_with(code) {
+                    return false;
+                }
+            }
+        }
+
+        if self.config.include.len() != 0 {
+            for code in &self.config.include {
+                if res.status.starts_with(code) {
                     self.results.push(res);
                     return true;
                 }

--- a/src/fuzzbuster/result_processor.rs
+++ b/src/fuzzbuster/result_processor.rs
@@ -77,7 +77,6 @@ impl FuzzScanProcessor {
         }
 
         false
-
     }
 
     pub fn save_fuzz_results(self, path: &str) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -705,6 +705,9 @@ fn main() {
                 output: output.to_owned(),
                 include_body: include_strings,
                 ignore_body: ignore_strings,
+                csrf_url: "".to_owned(),
+                csrf_regex: "".to_owned(),
+                csrf_headers: vec!(),
             };
 
             debug!("FuzzBuster {:#?}", fuzzbuster);

--- a/src/main.rs
+++ b/src/main.rs
@@ -285,6 +285,23 @@ fn main() {
         .map(|s| s.to_string())
         .collect::<Vec<String>>();
     let output = matches.value_of("output").unwrap();
+    let csrf_url = match matches.value_of("csrf-url") {
+        Some(v) => Some(v.to_owned()),
+        None => None,
+    };
+    let csrf_regex = match matches.value_of("csrf-regex") {
+        Some(v) => Some(v.to_owned()),
+        None => None,
+    };
+    let csrf_headers: Option<Vec<(String, String)>> = if matches.is_present("csrf-header") {
+        Some(matches
+            .values_of("csrf-header")
+            .unwrap()
+            .map(|h| dirbuster::utils::split_http_headers(h))
+            .collect())
+    } else {
+        None
+    };
 
     match url.parse::<hyper::Uri>() {
         Err(e) => {
@@ -705,9 +722,9 @@ fn main() {
                 output: output.to_owned(),
                 include_body: include_strings,
                 ignore_body: ignore_strings,
-                csrf_url: "".to_owned(),
-                csrf_regex: "".to_owned(),
-                csrf_headers: vec!(),
+                csrf_url,
+                csrf_regex,
+                csrf_headers,
             };
 
             debug!("FuzzBuster {:#?}", fuzzbuster);

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,8 +12,8 @@ use std::{str::FromStr, sync::mpsc::channel, thread, time::SystemTime};
 mod banner;
 mod dirbuster;
 mod dnsbuster;
-mod vhostbuster;
 mod fuzzbuster;
+mod vhostbuster;
 
 use dirbuster::{
     result_processor::{ResultProcessorConfig, ScanResult, SingleDirScanResult},
@@ -25,17 +25,20 @@ use dnsbuster::{
     utils::*,
     DnsConfig,
 };
+use fuzzbuster::FuzzBuster;
 use vhostbuster::{
     result_processor::{SingleVhostScanResult, VhostScanResult},
     utils::*,
     VhostConfig,
 };
-use fuzzbuster::{
-    FuzzBuster,
-};
 
 fn main() {
-    if std::env::vars().filter(|(name, _value)| name == "RUST_LOG").collect::<Vec<(String, String)>>().len() == 0 {
+    if std::env::vars()
+        .filter(|(name, _value)| name == "RUST_LOG")
+        .collect::<Vec<(String, String)>>()
+        .len()
+        == 0
+    {
         std::env::set_var("RUST_LOG", "rustbuster=warn");
     }
 
@@ -233,7 +236,11 @@ fn main() {
     let http_method = matches.value_of("http-method").unwrap();
     let http_body = matches.value_of("http-body").unwrap();
     let url = matches.value_of("url").unwrap();
-    let wordlist_paths = matches.values_of("wordlist").unwrap().map(|w| w.to_owned()).collect::<Vec<String>>();
+    let wordlist_paths = matches
+        .values_of("wordlist")
+        .unwrap()
+        .map(|w| w.to_owned())
+        .collect::<Vec<String>>();
     let mode = matches.value_of("mode").unwrap();
     let ignore_certificate = matches.is_present("ignore-certificate");
     let mut no_banner = matches.is_present("no-banner");
@@ -316,39 +323,43 @@ fn main() {
         None => None,
     };
     let csrf_headers: Option<Vec<(String, String)>> = if matches.is_present("csrf-header") {
-        Some(matches
-            .values_of("csrf-header")
-            .unwrap()
-            .map(|h| dirbuster::utils::split_http_headers(h))
-            .collect())
+        Some(
+            matches
+                .values_of("csrf-header")
+                .unwrap()
+                .map(|h| dirbuster::utils::split_http_headers(h))
+                .collect(),
+        )
     } else {
         None
     };
 
     match url.parse::<hyper::Uri>() {
         Err(e) => {
-            error!("Invalid URL: {}, consider adding a protocol like http:// or https://", e);
+            error!(
+                "Invalid URL: {}, consider adding a protocol like http:// or https://",
+                e
+            );
             return;
         }
-        Ok(v) => {
-            match v.scheme_part() {
-                Some(s) => {
-                    if s != "http" && s != "https" {
-                        error!("Invalid URL: invalid protocol, only http:// or https:// are supported");
-                        return;
-                    }
-                },
-                None => {
-                    if mode != "dns" {
-                        error!("Invalid URL: missing protocol, consider adding http:// or https://");
-                        return;
-                    }
-                },
+        Ok(v) => match v.scheme_part() {
+            Some(s) => {
+                if s != "http" && s != "https" {
+                    error!("Invalid URL: invalid protocol, only http:// or https:// are supported");
+                    return;
+                }
+            }
+            None => {
+                if mode != "dns" {
+                    error!("Invalid URL: missing protocol, consider adding http:// or https://");
+                    return;
+                }
             }
         },
     }
 
-    let all_wordlists_exist = wordlist_paths.iter()
+    let all_wordlists_exist = wordlist_paths
+        .iter()
         .map(|wordlist_path| {
             if std::fs::metadata(wordlist_path).is_err() {
                 error!("Specified wordlist does not exist: {}", wordlist_path);
@@ -358,7 +369,7 @@ fn main() {
             }
         })
         .fold(true, |acc, e| acc && e);
-    
+
     if !all_wordlists_exist {
         return;
     }
@@ -752,7 +763,7 @@ fn main() {
             debug!("FuzzBuster {:#?}", fuzzbuster);
 
             fuzzbuster.run();
-        },
+        }
         _ => (),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,6 +203,28 @@ fn main() {
                 .conflicts_with("ignore-string")
                 .takes_value(true),
         )
+        .arg(
+            Arg::with_name("csrf-url")
+                .long("csrf-url")
+                .help("Grabs the CSRF token via GET to csrf-url")
+                .requires("csrf-regex")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("csrf-regex")
+                .long("csrf-regex")
+                .help("Grabs the CSRF token applying the specified RegEx")
+                .requires("csrf-url")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("csrf-header")
+                .long("csrf-header")
+                .help("Adds the specified headers to CSRF GET request")
+                .requires("csrf-url")
+                .multiple(true)
+                .takes_value(true),
+        )
         .get_matches();
 
     let domain = matches.value_of("domain").unwrap_or("");


### PR DESCRIPTION
will fix #17 

example usage:
`env RUST_BACKTRACE=1 RUST_LOG=rustbuster=debug cargo run -- -m fuzz -u http://localhost:3000/login -X POST -H "Content-Type: application/json" -b '{"user":"FUZZ","password":"FUZZ","csrf":"CSRF"}' -w examples/wordlist -w /usr/share/seclists/Passwords/Common-Credentials/10-million-password-list-top-10000.txt -s 200 --csrf-url "http://localhost:3000/csrf" --csrf-regex '\{"csrf":"(\w+)"\}'`