### PR TITLE
fix: add metadata for crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,8 @@ name = "rustbuster"
 version = "3.0.3"
 authors = ["phra <greensoncio@gmail.com>", "ps1dr3x <michele@federici.tech>"]
 edition = "2018"
+description="A Comprehensive Web Fuzzer and Content Discovery Tool"
+license="GPL-3.0-or-later"
 
 [[bin]]
 name = "rustbuster"


### PR DESCRIPTION
Right now the license metadata in crates.io does not match with LICENSE in the repo. Update metadata for it.

![image](https://github.com/phra/rustbuster/assets/1580956/3ca7a49d-68ac-433f-b395-cec1b2f82246)
